### PR TITLE
🐛 fix(theme): typo & Cusdis dark‑mode sync

### DIFF
--- a/components/comments/cusdis.jsx
+++ b/components/comments/cusdis.jsx
@@ -1,18 +1,21 @@
 import { ReactCusdis } from 'react-cusdis'
 import { useRouter } from 'next/router'
 import { useConfig } from '@/contexts/config'
+import { useTheme } from "@/contexts/theme";
 
 export default function Cusdis ({ config, post }) {
   const router = useRouter()
-  const { link, lang, appearance } = useConfig()
+  const { link, lang } = useConfig()
+  const { scheme } = useTheme()
 
   return (
     <ReactCusdis
+      key={`cusdis-${scheme}`}
       attrs={{
         pageId: post.id,
         pageTitle: post.title,
         pageUrl: link + router.asPath,
-        theme: appearance,
+        theme: scheme,
         ...config,
       }}
       lang={resolveLang(lang)}

--- a/contexts/theme.tsx
+++ b/contexts/theme.tsx
@@ -17,7 +17,7 @@ const ThemeContext = createContext<Context>(undefined as any)
 export function ThemeProvider ({ children }: BasicProps) {
   const config = useConfig()
 
-  const [theme, setTheme] = useState<Theme>(config.appearance === 'auto' ? 'system' : config.appearnce)
+  const [theme, setTheme] = useState<Theme>(config.appearance === 'auto' ? 'system' : config.appearance)
 
   const [prefersDark, setPrefersDark] = useState<boolean>()
 


### PR DESCRIPTION
✏️ Problem Description
The Cusdis comment widget doesn’t respect the site’s theme setting:

1. Initial render – Cusdis always receives "auto" and falls back to its default colors, so it may mismatch the rest of the page.

2. Theme toggle – When the user switches between light / dark, Cusdis doesn’t update and sometimes freezes (the iframe stays mounted with the old styles).

🔧 What This Patch Does
- Fetches the resolved scheme ('light' or 'dark') from useTheme() instead of passing the raw appearance config.

- Adds a key={\cusdis-${scheme}`}` prop, forcing React to remount the widget whenever the scheme changes. This refreshes the iframe and eliminates the freeze.