### PR TITLE
🐛Fix: correct utterances theme when appearance is set to "auto"

### DIFF
--- a/components/comments/cusdis.jsx
+++ b/components/comments/cusdis.jsx
@@ -1,18 +1,21 @@
 import { ReactCusdis } from 'react-cusdis'
 import { useRouter } from 'next/router'
 import { useConfig } from '@/contexts/config'
+import { useTheme } from "@/contexts/theme";
 
 export default function Cusdis ({ config, post }) {
   const router = useRouter()
-  const { link, lang, appearance } = useConfig()
+  const { link, lang } = useConfig()
+  const { scheme } = useTheme()
 
   return (
     <ReactCusdis
+      key={`cusdis-${scheme}`}
       attrs={{
         pageId: post.id,
         pageTitle: post.title,
         pageUrl: link + router.asPath,
-        theme: appearance,
+        theme: scheme,
         ...config,
       }}
       lang={resolveLang(lang)}

--- a/components/comments/utterances.jsx
+++ b/components/comments/utterances.jsx
@@ -1,13 +1,10 @@
 import { useEffect, useRef } from 'react'
-import { useConfig } from '@/contexts/config'
+import { useTheme } from '@/contexts/theme'
 
 export default function Utterances ({ config, post }) {
-  const { appearance } = useConfig()
-  const theme = {
-    auto: 'preferred-color-scheme',
-    light: 'github-light',
-    dark: 'github-dark',
-  }[appearance]
+  const { scheme } = useTheme()
+
+  const theme = scheme === 'dark' ? 'github-dark' : 'github-light'
 
   const container = useRef()
 

--- a/contexts/theme.tsx
+++ b/contexts/theme.tsx
@@ -17,7 +17,7 @@ const ThemeContext = createContext<Context>(undefined as any)
 export function ThemeProvider ({ children }: BasicProps) {
   const config = useConfig()
 
-  const [theme, setTheme] = useState<Theme>(config.appearance === 'auto' ? 'system' : config.appearnce)
+  const [theme, setTheme] = useState<Theme>(config.appearance === 'auto' ? 'system' : config.appearance)
 
   const [prefersDark, setPrefersDark] = useState<boolean>()
 


### PR DESCRIPTION
## What this PR does

When `appearance` is set to `"auto"`, the current implementation maps the theme to `"preferred-color-scheme"`, which is **not a valid value** for the `theme` parameter in Utterances.

This PR updates the component to use the actual runtime color scheme from `useTheme()` instead. Now `"auto"` mode correctly resolves to either `"github-dark"` or `"github-light"` at runtime.

---

## Why this matters

Without this fix, the Utterances comment box always defaults to its own theme, regardless of the site’s appearance. This causes inconsistency when using dark mode or switching themes.

The new behavior ensures that Utterances always aligns with the current site theme, making the comment section visually coherent.

---

Let me know if you'd prefer a different approach — happy to adjust!
